### PR TITLE
Limit `/check_api` Invocations to Once Every 15 Minutes per Server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ keywords = [
 ]
 dependencies = [
   "aiohttp==3.8.5",
-  "asyncache==0.3.1",
-  "cachetools==5.3.1",
   "fastapi==0.103.2",
   "python_dateutil==2.8.2",
   "pytz==2023.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ keywords = [
 ]
 dependencies = [
   "aiohttp==3.8.5",
+  "asyncache==0.3.1",
+  "cachetools==5.3.1",
   "fastapi==0.103.2",
   "python_dateutil==2.8.2",
   "pytz==2023.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ test = [
     "black==23.9.1",
     "httpx==0.25.0",
     "pylint==2.17.5",
-    "pytest==7.4.2"
+    "pytest==7.4.2",
+    "pytest-asyncio==0.21.1"
 ]
 
 [project.urls]
@@ -43,4 +44,7 @@ Repository = "https://github.com/hackgvl/slack-events-bot.git"
 pythonpath = [
   ".",
   "src"
+]
+norecursedirs = [
+  "tests/helpers"
 ]

--- a/src/bot.py
+++ b/src/bot.py
@@ -247,7 +247,9 @@ async def check_api_on_cooldown(team_domain: Union[str, None]) -> bool:
     if expiry is None:
         return False
 
-    if datetime.datetime.now(datetime.timezone.utc) > datetime.datetime.fromisoformat(expiry):
+    if datetime.datetime.now(datetime.timezone.utc) > datetime.datetime.fromisoformat(
+        expiry
+    ):
         return False
 
     return True

--- a/src/bot.py
+++ b/src/bot.py
@@ -18,7 +18,6 @@ from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import PlainTextResponse
 from slack_bolt.async_app import AsyncApp
 from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
-from starlette.background import BackgroundTask
 from starlette.types import Message
 
 import database

--- a/src/bot.py
+++ b/src/bot.py
@@ -10,6 +10,9 @@ import traceback
 import aiohttp
 import pytz
 import uvicorn
+
+from asyncache import cached
+from cachetools import TTLCache
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import PlainTextResponse
 from slack_bolt.async_app import AsyncApp
@@ -17,6 +20,9 @@ from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
 import database
 
 from event import Event
+
+# 50kb - Current API responses are around ~11.7kb as of 09/30/2023
+MAX_BYTES = 50000
 
 # configure app
 APP = AsyncApp(
@@ -81,6 +87,7 @@ async def trigger_check_api(ack, say, logger, command):
         await check_api(CONN)
 
 
+@cached(cache=TTLCache(maxsize=MAX_BYTES, ttl=15 * 60))
 async def check_api(conn):
     """Check the api for updates and update any existing messages"""
     async with aiohttp.ClientSession() as session:
@@ -197,36 +204,6 @@ async def post_or_update_messages(conn, week, blocks, text):
 
 
 API = FastAPI()
-
-
-def check_api_being_requested(path: str, payload: bytes) -> bool:
-    """Determines if a user is attempting to execute the /check_api command."""
-    decoded_payload = payload.decode("utf-8")
-
-    return path == "/slack/events" and "command=%2Fcheck_api" in decoded_payload
-
-
-def check_api_on_cooldown() -> bool:
-    """Checks to see if the /check_api command has been run in the last 15 minutes."""
-    return True
-
-
-@API.middleware("http")
-async def rate_limit_check_api(req: Request, call_next):
-    """Looks to see if /check_api has been run recently, and returns an error if so."""
-
-    if (
-        check_api_being_requested(req.scope["path"], await req.body())
-        and check_api_on_cooldown()
-    ):
-        return PlainTextResponse(
-            (
-                "This command has been run recently and is on a cooldown period. "
-                "Please try again in a little while!"
-            )
-        )
-
-    return await call_next(req)
 
 
 @API.post("/slack/events")

--- a/src/bot.py
+++ b/src/bot.py
@@ -79,9 +79,6 @@ async def remove_channel(ack, say, logger, command):
 @APP.command("/check_api")
 async def trigger_check_api(ack, say, logger, command):
     """Handle manually rechecking the api for updates"""
-
-    print("\n\n\n\n\ntest\n\n\n\n\n")
-
     del say
     logger.info(f"{command['command']} from {command['channel_id']}")
     if command["channel_id"] is not None:
@@ -292,9 +289,6 @@ async def rate_limit_check_api(
 @API.post("/slack/events")
 async def endpoint(req: Request):
     """The front door for all Slack requests"""
-    print("hitting da slack")
-    print(req)
-    print(req.headers)
     return await APP_HANDLER.handle(req)
 
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -314,7 +314,7 @@ async def rate_limit_check_api(
 
 
 @API.post("/slack/events")
-async def endpoint(req: Request):
+async def slack_endpoint(req: Request):
     """The front door for all Slack requests"""
     return await APP_HANDLER.handle(req)
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -269,7 +269,9 @@ async def set_body(req: Request, body: bytes):
     Overrides the Request class's __receive method as a workaround to an issue
     where accessing a request body in middleware causes it to become blocking.
 
-    See https://github.com/tiangolo/fastapi/discussions/8187
+    See https://github.com/tiangolo/fastapi/discussions/8187 for the discussion
+    and this post (https://github.com/tiangolo/fastapi/discussions/8187#discussioncomment-5148049)
+    for where this code originates. Thanks, https://github.com/liukelin!
     """
     async def receive() -> Message:
         return {"type": "http.request", "body": body}

--- a/src/bot.py
+++ b/src/bot.py
@@ -85,7 +85,6 @@ async def trigger_check_api(ack, say, logger, command):
         await check_api(CONN)
 
 
-@cached(cache=TTLCache(maxsize=MAX_BYTES, ttl=15 * 60))
 async def check_api(conn):
     """Check the api for updates and update any existing messages"""
     async with aiohttp.ClientSession() as session:
@@ -203,6 +202,7 @@ async def post_or_update_messages(conn, week, blocks, text):
 
 API = FastAPI()
 
+
 def check_api_being_requested(path: str, payload: bytes) -> bool:
     """Determines if a user is attempting to execute the /check_api command."""
     decoded_payload = payload.decode("utf-8")
@@ -211,7 +211,9 @@ def check_api_being_requested(path: str, payload: bytes) -> bool:
 
 
 def check_api_on_cooldown() -> bool:
-    """Checks to see if the /check_api command has been run in the last 15 minutes."""
+    """Checks to see if the /check_api command has been run in the last 15 minutes in the
+    specified server (denoted by its base_url).
+    """
     return True
 
 
@@ -230,7 +232,8 @@ async def rate_limit_check_api(req: Request, call_next):
             )
         )
 
-    return await call_next(req
+    return await call_next(req)
+
 
 @API.post("/slack/events")
 async def endpoint(req: Request):

--- a/src/bot.py
+++ b/src/bot.py
@@ -14,7 +14,6 @@ import uvicorn
 from asyncache import cached
 from cachetools import TTLCache
 from fastapi import FastAPI, Request, HTTPException
-from fastapi.responses import PlainTextResponse
 from slack_bolt.async_app import AsyncApp
 from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
 import database

--- a/src/bot.py
+++ b/src/bot.py
@@ -11,6 +11,7 @@ import aiohttp
 import pytz
 import uvicorn
 from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import PlainTextResponse
 from slack_bolt.async_app import AsyncApp
 from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
 import database
@@ -196,6 +197,36 @@ async def post_or_update_messages(conn, week, blocks, text):
 
 
 API = FastAPI()
+
+
+def check_api_being_requested(path: str, payload: bytes) -> bool:
+    """Determines if a user is attempting to execute the /check_api command."""
+    decoded_payload = payload.decode("utf-8")
+
+    return path == "/slack/events" and "command=%2Fcheck_api" in decoded_payload
+
+
+def check_api_on_cooldown() -> bool:
+    """Checks to see if the /check_api command has been run in the last 15 minutes."""
+    return True
+
+
+@API.middleware("http")
+async def rate_limit_check_api(req: Request, call_next):
+    """Looks to see if /check_api has been run recently, and returns an error if so."""
+
+    if (
+        check_api_being_requested(req.scope["path"], await req.body())
+        and check_api_on_cooldown()
+    ):
+        return PlainTextResponse(
+            (
+                "This command has been run recently and is on a cooldown period. "
+                "Please try again in a little while!"
+            )
+        )
+
+    return await call_next(req)
 
 
 @API.post("/slack/events")

--- a/src/bot.py
+++ b/src/bot.py
@@ -247,7 +247,7 @@ async def check_api_on_cooldown(team_domain: Union[str, None]) -> bool:
     if expiry is None:
         return False
 
-    if datetime.datetime.now() > datetime.datetime.fromisoformat(expiry):
+    if datetime.datetime.now(datetime.timezone.utc) > datetime.datetime.fromisoformat(expiry):
         return False
 
     return True

--- a/src/database.py
+++ b/src/database.py
@@ -1,185 +1,192 @@
 """Contains all the functions that interact with the sqlite database"""
-
+import os
 import datetime
 import sqlite3
-from typing import Union
+from typing import Union, Generator
+
+DB_PATH = os.path.abspath(os.environ.get("DB_PATH", "./slack-events-bot.db"))
 
 
-def create_tables(conn):
+def get_connection(commit: bool = False) -> Generator:
+    """
+    Yields a SQLite connection to another method.
+
+    Once the other method has finished,
+    the transaction if committed if the commit parameter is true,
+    and then the connection is always closed.
+    """
+    conn = sqlite3.connect(DB_PATH)
+
+    yield conn
+
+    if commit:
+        conn.commit()
+
+    conn.close()
+
+
+def create_tables():
     """Create database tables needed for slack events bot"""
-    cur = conn.cursor()
+    for conn in get_connection(commit=True):
+        cur = conn.cursor()
+        cur.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS channels (
+                id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                slack_channel_id TEXT UNIQUE NOT NULL
+            );
 
-    cur.executescript(
+            CREATE INDEX IF NOT EXISTS slack_channel_id_index ON channels (slack_channel_id);
+
+            CREATE TABLE IF NOT EXISTS messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                week DATE NOT NULL,
+                message_timestamp TEXT NOT NULL,
+                message TEXT NOT NULL,
+                channel_id INTEGER NOT NULL,
+                    CONSTRAINT fk_channel_id
+                    FOREIGN KEY(channel_id) REFERENCES channels(id)
+                    ON DELETE CASCADE
+            );
+
+            CREATE INDEX IF NOT EXISTS week_index ON messages (week);
+
+            CREATE TABLE IF NOT EXISTS cooldowns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                -- Unique identifier from whomever is accessing the resource.
+                -- Can be a workspace, channel, user, etc..
+                accessor TEXT NOT NULL,
+                -- Unique identifier for whatever is rate-limited.
+                -- Can be a method name, service name, etc..
+                resource TEXT NOT NULL,
+                -- ISO8601 timestamp for when the accessor
+                -- will be allowed to access the resource once again.
+                expires_at TEXT NOT NULL,
+                UNIQUE(accessor,resource)
+            );
+
+            CREATE INDEX IF NOT EXISTS accessor_resource_index ON
+                cooldowns (accessor, resource);
         """
-		CREATE TABLE IF NOT EXISTS channels (
-			id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-			slack_channel_id TEXT UNIQUE NOT NULL
-		);
-
-		CREATE INDEX IF NOT EXISTS slack_channel_id_index ON channels (slack_channel_id);
-
-		CREATE TABLE IF NOT EXISTS messages (
-			id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-			week DATE NOT NULL,
-			message_timestamp TEXT NOT NULL,
-            message TEXT NOT NULL,
-			channel_id INTEGER NOT NULL,
-				CONSTRAINT fk_channel_id
-				FOREIGN KEY(channel_id) REFERENCES channels(id)
-				ON DELETE CASCADE
-		);
-
-		CREATE INDEX IF NOT EXISTS week_index ON messages (week);
-
-        CREATE TABLE IF NOT EXISTS cooldowns (
-            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-              -- Unique identifier from whomever is accessing the resource. Can be a workspace, channel, user, etc..
-            accessor TEXT NOT NULL,
-              -- Unique identifier for whatever is rate-limited. Can be a method name, service name, etc..
-            resource TEXT NOT NULL,
-            -- ISO8601 timestamp for when the accessor will be allowed to access the resource once again.
-            expires_at TEXT NOT NULL,
-            UNIQUE(accessor,resource)
-        );
-
-        CREATE INDEX IF NOT EXISTS accessor_resource_index ON
-            cooldowns (accessor, resource);
-	"""
-    )
-
-    # saves the change to the database
-    conn.commit()
+        )
 
 
-async def create_message(conn, week, message, message_timestamp, slack_channel_id):
+async def create_message(week, message, message_timestamp, slack_channel_id):
     """Create a record of a message sent in slack for a week"""
-    cur = conn.cursor()
+    for conn in get_connection(commit=True):
+        cur = conn.cursor()
+        # get database's channel id for slack channel id
+        cur.execute(
+            "SELECT id FROM channels WHERE slack_channel_id = ?", [slack_channel_id]
+        )
+        channel_id = cur.fetchone()[0]
 
-    # get database's channel id for slack channel id
-    cur.execute(
-        "SELECT id FROM channels WHERE slack_channel_id = ?", [slack_channel_id]
-    )
-    channel_id = cur.fetchone()[0]
-
-    cur.execute(
-        """INSERT INTO messages (week, message, message_timestamp, channel_id)
-            VALUES (?, ?, ?, ?)""",
-        [week, message, message_timestamp, channel_id],
-    )
-
-    # saves the change to the database
-    conn.commit()
+        cur.execute(
+            """INSERT INTO messages (week, message, message_timestamp, channel_id)
+                VALUES (?, ?, ?, ?)""",
+            [week, message, message_timestamp, channel_id],
+        )
 
 
-async def update_message(conn, week, message, message_timestamp, slack_channel_id):
+async def update_message(week, message, message_timestamp, slack_channel_id):
     """Updates a record of a message sent in slack for a week"""
-    cur = conn.cursor()
+    for conn in get_connection(commit=True):
+        cur = conn.cursor()
+        # get database's channel id for slack channel id
+        cur.execute(
+            "SELECT id FROM channels WHERE slack_channel_id = ?", [slack_channel_id]
+        )
+        channel_id = cur.fetchone()[0]
 
-    # get database's channel id for slack channel id
-    cur.execute(
-        "SELECT id FROM channels WHERE slack_channel_id = ?", [slack_channel_id]
-    )
-    channel_id = cur.fetchone()[0]
-
-    cur.execute(
-        """UPDATE messages
-            SET message = ?
-            WHERE week = ? AND message_timestamp = ? AND channel_id = ?""",
-        [message, week, message_timestamp, channel_id],
-    )
-
-    # saves the change to the database
-    conn.commit()
+        cur.execute(
+            """UPDATE messages
+                SET message = ?
+                WHERE week = ? AND message_timestamp = ? AND channel_id = ?""",
+            [message, week, message_timestamp, channel_id],
+        )
 
 
-async def get_messages(conn, week):
+async def get_messages(week):
     """Get all messages sent in slack for a week"""
-    cur = conn.cursor()
-    cur.execute(
-        """SELECT m.message, m.message_timestamp, c.slack_channel_id
-            FROM messages m
-            JOIN channels c ON m.channel_id = c.id
-            WHERE m.week = ?""",
-        [week],
-    )
-    return [
-        {"message": x[0], "message_timestamp": x[1], "slack_channel_id": x[2]}
-        for x in cur.fetchall()
-    ]
+    for conn in get_connection():
+        cur = conn.cursor()
+        cur.execute(
+            """SELECT m.message, m.message_timestamp, c.slack_channel_id
+                FROM messages m
+                JOIN channels c ON m.channel_id = c.id
+                WHERE m.week = ?""",
+            [week],
+        )
+        return [
+            {"message": x[0], "message_timestamp": x[1], "slack_channel_id": x[2]}
+            for x in cur.fetchall()
+        ]
 
 
-async def get_slack_channel_ids(conn):
+async def get_slack_channel_ids():
     """Get all slack channels that the bot is configured for"""
-    cur = conn.cursor()
-    cur.execute("SELECT slack_channel_id FROM channels")
-    return [x[0] for x in cur.fetchall()]
+    for conn in get_connection():
+        cur = conn.cursor()
+        cur.execute("SELECT slack_channel_id FROM channels")
+        return [x[0] for x in cur.fetchall()]
 
 
-async def add_channel(conn, slack_channel_id):
+async def add_channel(slack_channel_id):
     """Add a slack channel to post in for the bot"""
-    cur = conn.cursor()
-    cur.execute(
-        "INSERT INTO channels (slack_channel_id) VALUES (?)", [slack_channel_id]
-    )
-
-    # saves the change to the database
-    conn.commit()
+    for conn in get_connection(commit=True):
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO channels (slack_channel_id) VALUES (?)", [slack_channel_id]
+        )
 
 
-async def remove_channel(conn, channel_id):
+async def remove_channel(channel_id):
     """Remove a slack channel to post in from the bot"""
-    cur = conn.cursor()
-    cur.execute("DELETE FROM channels WHERE slack_channel_id = ?", [channel_id])
-
-    # saves the change to the database
-    conn.commit()
+    for conn in get_connection(commit=True):
+        cur = conn.cursor()
+        cur.execute("DELETE FROM channels WHERE slack_channel_id = ?", [channel_id])
 
 
-async def create_cooldown(
-    conn: sqlite3.Connection, accessor: str, resource: str, cooldown_minutes: int
-) -> None:
+async def create_cooldown(accessor: str, resource: str, cooldown_minutes: int) -> None:
     """
     Upserts a cooldown record for an entity which will let the system know when to make the resource
     available to them once again.
     """
-    cur = conn.cursor()
+    for conn in get_connection(commit=True):
+        cur = conn.cursor()
+        cur.execute(
+            """INSERT INTO cooldowns (accessor, resource, expires_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(accessor,resource) DO UPDATE SET
+                    accessor=excluded.accessor,
+                    resource=excluded.resource,
+                    expires_at=excluded.expires_at
+            """,
+            [
+                accessor,
+                resource,
+                (
+                    datetime.datetime.now()
+                    + datetime.timedelta(minutes=cooldown_minutes)
+                ).isoformat(),
+            ],
+        )
 
-    cur.execute(
-        """INSERT INTO cooldowns (accessor, resource, expires_at)
-            VALUES (?, ?, ?)
-            ON CONFLICT(accessor,resource) DO UPDATE SET
-                accessor=excluded.accessor,
-                resource=excluded.resource,
-                expires_at=excluded.expires_at
-        """,
-        [
-            accessor,
-            resource,
-            (
-                datetime.datetime.now() + datetime.timedelta(minutes=cooldown_minutes)
-            ).isoformat(),
-        ],
-    )
 
-    conn.commit()
-
-
-async def get_cooldown_expiry_time(
-    conn: sqlite3.Connection, accessor: str, resource: str
-) -> Union[str, None]:
+async def get_cooldown_expiry_time(accessor: str, resource: str) -> Union[str, None]:
     """
     Returns the time at which an accessor is able to access a resource
     or None if no restriction has ever been put in place.
     """
-    cur = conn.cursor()
+    for conn in get_connection():
+        cur = conn.cursor()
+        cur.execute(
+            """SELECT expires_at FROM cooldowns
+            WHERE accessor = ? AND resource = ?
+            """,
+            [accessor, resource],
+        )
 
-    cur.execute(
-        """SELECT expires_at FROM cooldowns
-           WHERE accessor = ? AND resource = ?
-        """,
-        [accessor, resource],
-    )
+        expiry_time = cur.fetchone()
 
-    expiry_time = cur.fetchone()
-
-    return expiry_time[0] if expiry_time is not None else None
+        return expiry_time[0] if expiry_time is not None else None

--- a/src/database.py
+++ b/src/database.py
@@ -166,7 +166,7 @@ async def create_cooldown(accessor: str, resource: str, cooldown_minutes: int) -
                 accessor,
                 resource,
                 (
-                    datetime.datetime.now()
+                    datetime.datetime.now(datetime.timezone.utc)
                     + datetime.timedelta(minutes=cooldown_minutes)
                 ).isoformat(),
             ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,6 @@ def db_cleanup():
     yield
 
     for conn in database.get_connection():
-
         cur = conn.cursor()
 
         cur.executescript(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,15 +22,15 @@ def threads_appear_dead(monkeypatch):
 
 
 @pytest.fixture
-def db_with_cleanup():
+def db_cleanup():
     """
-    Fixture to provide a DB connection to tests and then ensure state doesn't bleed over
-    between them.
+    Fixture to clean the database after tests.
     """
     database.create_tables()
 
+    yield
+
     for conn in database.get_connection():
-        yield conn
 
         cur = conn.cursor()
 
@@ -39,7 +39,9 @@ def db_with_cleanup():
             SELECT 'DELETE FROM ' || name
             FROM sqlite_master
             WHERE type = 'table';
-
-            VACUUM;
             """
         )
+
+        conn.commit()
+
+        conn.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
-import os
+"""Pytest Fixtures"""
+
 import pytest
 from fastapi.testclient import TestClient
 from threading import Thread
 
 from bot import API
+import database
 
 
 @pytest.fixture
@@ -16,3 +18,27 @@ def test_client():
 def threads_appear_dead(monkeypatch):
     """Include this fixture if you'd like for all your threads to be reported as dead."""
     monkeypatch.setattr(Thread, "is_alive", lambda x: False)
+
+
+@pytest.fixture
+def db_with_cleanup():
+    """
+    Fixture to provide a DB connection to tests and then ensure state doesn't bleed over
+    between them.
+    """
+    database.create_tables()
+
+    for conn in database.get_connection():
+        yield conn
+
+        cur = conn.cursor()
+
+        cur.executescript(
+            """
+            SELECT 'DELETE FROM ' || name
+            FROM sqlite_master
+            WHERE type = 'table';
+
+            VACUUM;
+            """
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 """Pytest Fixtures"""
+from threading import Thread
 
 import pytest
 from fastapi.testclient import TestClient
-from threading import Thread
+
 
 from bot import API
 import database

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+from .utils import *

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,1 +1,2 @@
+"""Module for housing Pytest helper functions"""
 from .utils import *

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -28,4 +28,6 @@ def create_slack_request_payload(
     )
 
     return bytes(sample_payload, "utf-8")
+
+
 # pylint: enable=too-many-arguments

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -28,3 +28,4 @@ def create_slack_request_payload(
     )
 
     return bytes(sample_payload, "utf-8")
+# pylint: enable=too-many-arguments

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -1,0 +1,30 @@
+"""Pytest Helper Functions"""
+
+import urllib.parse
+
+
+# pylint: disable=too-many-arguments
+def create_slack_request_payload(
+    command: str,
+    token: str = "1CnbxdlkN3Ag2AafGvsp81za",
+    team_id: str = "LGPpTuQPsQx",
+    team_domain: str = "super_cool_domain",
+    channel_id: str = "jhVOsIAWtNW",
+    channel_name: str = "Testing",
+    user_id: str = "2xIIwe9Rs6y",
+    user_name: str = "thetester",
+    text: str = "",
+    api_app_id: str = "QpysuvDZwgb",
+    is_enterprise_install: str = "false",
+    response_url: str = "https://hooks.slack.com/commands/some-info",
+) -> bytes:
+    """Creates a representative payload that we would expect to receive from Slack's API."""
+    sample_payload = (
+        f"token={token}&team_id={team_id}&team_domain={team_domain}&channel_id{channel_id}&"
+        f"channel_name={channel_name}&user_id={user_id}"
+        f"&user_name={user_name}&command={urllib.parse.quote_plus(command)}&"
+        f"text={text}&api_app_id={api_app_id}&is_enterprise_install={is_enterprise_install}&"
+        f"response_url={urllib.parse.quote_plus(response_url)}"
+    )
+
+    return bytes(sample_payload, "utf-8")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,11 +1,12 @@
 """
     Tests for the bot.py file.
 """
-import pytest
 import threading
+import pytest
 
-import database
 import helpers
+import database
+
 
 
 def test_health_check_healthy_threads(test_client):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -16,8 +16,9 @@ def test_health_check_healthy_threads(test_client):
     assert response.content == b'{"detail":"Everything is lookin\' good!"}'
 
 
-
-def test_health_check_with_a_dead_thread(test_client, threads_appear_dead): # pylint: disable=unused-argument
+def test_health_check_with_a_dead_thread(
+    test_client, threads_appear_dead
+):  # pylint: disable=unused-argument
     """Tests what happens if a dead thread is found whenever this endpoint is hit."""
     response = test_client.get("healthz")
 
@@ -37,7 +38,9 @@ RATE_LIMIT_COPY = (
 )
 
 
-def test_check_api_whenever_someone_executes_it_for_first_time(test_client, db_cleanup): # pylint: disable=unused-argument
+def test_check_api_whenever_someone_executes_it_for_first_time(
+    test_client, db_cleanup
+):  # pylint: disable=unused-argument
     """Whenever an entity executes /check_api for the first time it should run successfully."""
     response = test_client.post(
         "/slack/events",
@@ -57,7 +60,7 @@ def test_check_api_whenever_someone_executes_it_for_first_time(test_client, db_c
 
 @pytest.mark.asyncio
 async def test_check_api_whenever_someone_executes_it_after_expiry(
-    test_client, db_cleanup
+    test_client, db_cleanup  # pylint: disable=unused-argument
 ):
     """
     Whenever an entity has run /check_api before, and their cooldown window has expired,
@@ -80,7 +83,7 @@ async def test_check_api_whenever_someone_executes_it_after_expiry(
 
 @pytest.mark.asyncio
 async def test_check_api_whenever_someone_executes_it_before_expiry(
-    test_client, db_cleanup # pylint: disable=unused-argument
+    test_client, db_cleanup  # pylint: disable=unused-argument
 ):
     """
     Whenever an entity has run /check_api before, and their cooldown window has NOT expired,
@@ -96,4 +99,3 @@ async def test_check_api_whenever_someone_executes_it_before_expiry(
     )
     assert response.status_code == 200
     assert response.content.decode("utf-8") == RATE_LIMIT_COPY
-

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -37,9 +37,7 @@ RATE_LIMIT_COPY = (
 )
 
 
-def test_check_api_whenever_someone_executes_it_for_first_time(
-    test_client, db_cleanup
-):
+def test_check_api_whenever_someone_executes_it_for_first_time(test_client, db_cleanup):
     """Whenever an entity executes /check_api for the first time it should run successfully."""
     response = test_client.post(
         "/slack/events",

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,8 +1,11 @@
 """
     Tests for the bot.py file.
 """
-
+import pytest
 import threading
+
+import database
+import helpers
 
 
 def test_health_check_healthy_threads(test_client):
@@ -13,6 +16,7 @@ def test_health_check_healthy_threads(test_client):
     assert response.content == b'{"detail":"Everything is lookin\' good!"}'
 
 
+# pylint: disable=unused-argument
 def test_health_check_with_a_dead_thread(test_client, threads_appear_dead):
     """Tests what happens if a dead thread is found whenever this endpoint is hit."""
     response = test_client.get("healthz")
@@ -23,3 +27,76 @@ def test_health_check_with_a_dead_thread(test_client, threads_appear_dead):
     assert response.json() == {
         "detail": f"The {first_thread.name} thread has died. This container will soon restart."
     }
+
+
+TEAM_DOMAIN = "team_awesome"
+
+RATE_LIMIT_COPY = (
+    "This command has been run recently and is on a cooldown period. "
+    "Please try again in a little while!"
+)
+
+
+def test_check_api_whenever_someone_executes_it_for_first_time(
+    test_client, db_with_cleanup
+):
+    """Whenever an entity executes /check_api for the first time it should run successfully."""
+    response = test_client.post(
+        "/slack/events",
+        content=helpers.create_slack_request_payload(
+            command="/check_api", team_domain=TEAM_DOMAIN
+        ),
+    )
+
+    # Until the Slack Bolt client is properly mocked this is about as specific as we
+    # can get. Right now we will receive a 401 response in our test suite
+    # since there are checks being performed to validate our fake token on Slack's side.
+    #
+    # If we get some response other than RATE_LIMIT_COPY that means rate-limiting is not
+    # occurring, so this is at least targeting that aspect (though, sloppily).
+    assert response.content.decode("utf-8") != RATE_LIMIT_COPY
+
+
+@pytest.mark.asyncio
+async def test_check_api_whenever_someone_executes_it_after_expiry(
+    test_client, db_with_cleanup
+):
+    """
+    Whenever an entity has run /check_api before, and their cooldown window has expired,
+    then they should be able to run the command again.
+    """
+    # Create a cooldown that has expired 20 minutes ago.
+    await database.create_cooldown(TEAM_DOMAIN, "check_api", -20)
+
+    response = test_client.post(
+        "/slack/events",
+        content=helpers.create_slack_request_payload(
+            command="/check_api", team_domain=TEAM_DOMAIN
+        ),
+    )
+
+    #
+    assert response.content.decode("utf-8") != RATE_LIMIT_COPY
+
+
+@pytest.mark.asyncio
+async def test_check_api_whenever_someone_executes_it_before_expiry(
+    test_client, db_with_cleanup
+):
+    """
+    Whenever an entity has run /check_api before, and their cooldown window has NOT expired,
+    then they should receive a message telling them to try again later.
+    """
+    await database.create_cooldown(TEAM_DOMAIN, "check_api", 15)
+
+    response = test_client.post(
+        "/slack/events",
+        content=helpers.create_slack_request_payload(
+            command="/check_api", team_domain=TEAM_DOMAIN
+        ),
+    )
+    assert response.status_code == 200
+    assert response.content.decode("utf-8") == RATE_LIMIT_COPY
+
+
+# pylint: enable=unused-argument

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -16,8 +16,8 @@ def test_health_check_healthy_threads(test_client):
     assert response.content == b'{"detail":"Everything is lookin\' good!"}'
 
 
-# pylint: disable=unused-argument
-def test_health_check_with_a_dead_thread(test_client, threads_appear_dead):
+
+def test_health_check_with_a_dead_thread(test_client, threads_appear_dead): # pylint: disable=unused-argument
     """Tests what happens if a dead thread is found whenever this endpoint is hit."""
     response = test_client.get("healthz")
 
@@ -37,7 +37,7 @@ RATE_LIMIT_COPY = (
 )
 
 
-def test_check_api_whenever_someone_executes_it_for_first_time(test_client, db_cleanup):
+def test_check_api_whenever_someone_executes_it_for_first_time(test_client, db_cleanup): # pylint: disable=unused-argument
     """Whenever an entity executes /check_api for the first time it should run successfully."""
     response = test_client.post(
         "/slack/events",
@@ -80,7 +80,7 @@ async def test_check_api_whenever_someone_executes_it_after_expiry(
 
 @pytest.mark.asyncio
 async def test_check_api_whenever_someone_executes_it_before_expiry(
-    test_client, db_cleanup
+    test_client, db_cleanup # pylint: disable=unused-argument
 ):
     """
     Whenever an entity has run /check_api before, and their cooldown window has NOT expired,
@@ -97,5 +97,3 @@ async def test_check_api_whenever_someone_executes_it_before_expiry(
     assert response.status_code == 200
     assert response.content.decode("utf-8") == RATE_LIMIT_COPY
 
-
-# pylint: enable=unused-argument

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -38,7 +38,7 @@ RATE_LIMIT_COPY = (
 
 
 def test_check_api_whenever_someone_executes_it_for_first_time(
-    test_client, db_with_cleanup
+    test_client, db_cleanup
 ):
     """Whenever an entity executes /check_api for the first time it should run successfully."""
     response = test_client.post(
@@ -59,7 +59,7 @@ def test_check_api_whenever_someone_executes_it_for_first_time(
 
 @pytest.mark.asyncio
 async def test_check_api_whenever_someone_executes_it_after_expiry(
-    test_client, db_with_cleanup
+    test_client, db_cleanup
 ):
     """
     Whenever an entity has run /check_api before, and their cooldown window has expired,
@@ -82,7 +82,7 @@ async def test_check_api_whenever_someone_executes_it_after_expiry(
 
 @pytest.mark.asyncio
 async def test_check_api_whenever_someone_executes_it_before_expiry(
-    test_client, db_with_cleanup
+    test_client, db_cleanup
 ):
     """
     Whenever an entity has run /check_api before, and their cooldown window has NOT expired,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -8,7 +8,6 @@ import helpers
 import database
 
 
-
 def test_health_check_healthy_threads(test_client):
     """Happy path scenario for the /healthz route where nothing is wrong."""
     response = test_client.get("healthz")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -75,7 +75,8 @@ async def test_check_api_whenever_someone_executes_it_after_expiry(
         ),
     )
 
-    #
+    # See:
+    # https://github.com/ThorntonMatthewD/slack-events-bot/blob/11f30d4655226faeaaf7ec4e4dd92eabd2230afb/tests/test_bot.py#L51
     assert response.content.decode("utf-8") != RATE_LIMIT_COPY
 
 


### PR DESCRIPTION
Fixes #5

# Summary
This change only allows for the `/check_api` command to be run on a server/workspace every 15 minutes. If a user from a workspace that has run this command within 15 minutes runs it again, they'll be greeted with this message:
> "This command has been run recently and is on a cooldown period. Please try again in a little while!"

Cooldowns are specific to each workspace, so users from one server aren't subject to a cooldown being enforced against another.

I've also extracted out the instantiation of the SQLite connection(s) from bot.py to database.py to make testing database-dependent functionality a little bit easier.

# Screenshots
A record in the `cooldowns` table where each server (or anything whose ID we'd want to put here) has a timestamp denoting when someone from there can run `/check_api` again.
![Screenshot_2023-10-01_20-54-18](https://github.com/hackgvl/slack-events-bot/assets/44626690/52f33d0a-d23d-4890-b062-f797d0b829b7)


What end users see if they hit the rate-limit.
![Screenshot_2023-10-01_20-43-55](https://github.com/hackgvl/slack-events-bot/assets/44626690/034e29ce-c696-4f85-a5ea-5c21561b7fb7)


# Test Plan
1. Fire up the bot locally and run the `/check_api` command in a workspace that your bot is integrated with.
2. Check for a new record in the `cooldowns` table.
   1. The `accessor` field will be the subdomain related to your workspace (`<accessor>.slack.com`).
   2. The `resource` field will be `check_api`.
   3. The `expires_at` time will be a timestamp in ISO8601 that should be the time 15 minutes from whenever you executed the `/check_api` command (in UTC).
3. Try running the command again. You shoud receive a message about how the command is on cooldown.
4. Adjust the `expires_at` timestamp to be an hour behind what it's currently set to and commit your change. Then try running the command again (it should work).
5. Extra spicy: If you have access to another workspace, verify that the timers are enforced on each server independently (Server B doesn't have a cooldown but Server A does).

I think it would also be good to test the other end-user-facing functionality (like `/add_channel` and `/remove_channel` just to ensure the DB refactor didn't booger anything up. 