### PR TITLE
Add Authorization to `/add_channel` and `/remove_channel`

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,44 @@
+"""
+Logic for restricting the use of Slack commands to specific parties
+"""
+
+from functools import wraps
+
+from config import SLACK_APP
+
+
+async def get_user_info(user_id: str):
+    """
+    Queries Slack's API for information about a particular user.
+
+    See https://api.slack.com/methods/users.info
+    """
+    return await SLACK_APP.client.users_info(user=user_id)
+
+
+async def is_admin(user_id: str) -> bool:
+    """
+    Gets info for the Slack user executing the command and checks if
+    they're a workspace admin.
+    """
+    user_info = await get_user_info(user_id)
+
+    return user_info.get("user", {}).get("is_admin", False)
+
+
+def admin_required(command):
+    """
+    Used to decorate Slack commands to ensure the executor is an admin
+    before proceeding with allowing the command to run.
+    """
+
+    @wraps(command)
+    async def auth_wrapper(*args, **kwargs):
+        if await is_admin(kwargs["command"]["user_id"]):
+            return await command(*args, **kwargs)
+
+        return await kwargs["ack"](
+            f"You must be a workspace admin in order to run `{kwargs['command']['command']}`"
+        )
+
+    return auth_wrapper

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,17 @@
+"""
+Location for configuration settings and app-wide constants.
+"""
+
+import os
+
+from fastapi import FastAPI
+from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
+from slack_bolt.async_app import AsyncApp
+
+API = FastAPI()
+
+# configure Slack app
+SLACK_APP = AsyncApp(
+    token=os.environ.get("BOT_TOKEN"), signing_secret=os.environ.get("SIGNING_SECRET")
+)
+SLACK_APP_HANDLER = AsyncSlackRequestHandler(SLACK_APP)

--- a/src/server.py
+++ b/src/server.py
@@ -14,14 +14,13 @@ from collections.abc import Awaitable, Callable
 from typing import Union
 
 import uvicorn
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import HTTPException, Request
 from fastapi.responses import PlainTextResponse
 from starlette.types import Message
 
 import database
-from bot import APP_HANDLER, periodically_check_api, periodically_delete_old_messages
-
-API = FastAPI()
+from bot import periodically_check_api, periodically_delete_old_messages
+from config import API, SLACK_APP_HANDLER
 
 
 async def identify_slack_team_domain(payload: bytes) -> Union[str, None]:
@@ -136,7 +135,7 @@ async def rate_limit_check_api(
 @API.post("/slack/events")
 async def slack_endpoint(req: Request):
     """The front door for all Slack requests"""
-    return await APP_HANDLER.handle(req)
+    return await SLACK_APP_HANDLER.handle(req)
 
 
 @API.get("/healthz", tags=["Utility"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,14 +8,15 @@ import pytest
 from fastapi.testclient import TestClient
 
 import bot
+import config
+import server
 import database
-from server import API
 
 
 @pytest.fixture
 def test_client():
     """Returns a Starlette test API instance"""
-    return TestClient(API)
+    return TestClient(server.API)
 
 
 @pytest.fixture
@@ -95,8 +96,8 @@ def single_event_data():
 
 
 @pytest.fixture
-def mock_slack_bolt_async_app(monkeypatch):
+def mock_slack_bolt_async_app(request, monkeypatch):
     """
     Monkeypatch slack_bolt.async_app's AsyncApp with our stub
     """
-    monkeypatch.setattr(bot, "APP", mocks.AsyncApp())
+    monkeypatch.setattr(f"{request.param}.SLACK_APP", mocks.AsyncApp())

--- a/tests/mocks/async_app.py
+++ b/tests/mocks/async_app.py
@@ -13,10 +13,21 @@ class Client:
         self, channel, blocks, text, unfurl_links, unfurl_media
     ):  # pylint: disable=invalid-name
         """Simulates posting a new Slack message"""
+        del channel, blocks, text, unfurl_links, unfurl_media
+
         return {"ts": "1503435956.000247"}
 
     async def chat_update(self, ts, channel, blocks, text):
         """Simulates updating an existing Slack message"""
+        del ts, channel, blocks, text
+
+    async def users_info(self, user=""):
+        """Simulates getting info on a user"""
+
+        return {
+            "ok": True,
+            "user": {"id": user, "name": "Tester", "is_admin": "admin" in user.lower()},
+        }
 
 
 class AsyncApp:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,26 @@
+"""
+Tests functions contained in src/auth.py
+"""
+
+import pytest
+
+import auth
+
+
+@pytest.mark.parametrize("mock_slack_bolt_async_app", ["auth"], indirect=True)
+class TestAuth:
+    """Groups tests for auth.py into a single scope"""
+
+    @pytest.mark.asyncio
+    async def test_is_admin_when_user_is_not_admin(self, mock_slack_bolt_async_app):
+        """Tests when a user is NOT a workspace admin"""
+        result = await auth.is_admin("regular_user")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_is_admin_when_user_is_admin(self, mock_slack_bolt_async_app):
+        """Tests when a user is a workspace admin"""
+        result = await auth.is_admin("admin_user")
+
+        assert result is True

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -10,90 +10,94 @@ import pytz
 import database
 from bot import post_or_update_messages
 
-
 week = datetime.datetime.strptime("10/22/2023", "%m/%d/%Y").replace(tzinfo=pytz.utc)
 
 
-@pytest.mark.asyncio
-async def test_post_or_update_messages_expansion_with_next_week_already_posted(
-    caplog, db_cleanup, mock_slack_bolt_async_app
-):
-    """
-    post_or_update_messages fails if it determines that a
-    weeks posts will require a new message(s), but the next week
-    has already had posts sent for it.
-    """
+@pytest.mark.parametrize("mock_slack_bolt_async_app", ["bot"], indirect=True)
+class TestBot:
+    """Groups tests for bot.py into a single scope"""
 
-    slack_id = "fake_slack_id"
+    @pytest.mark.asyncio
+    async def test_post_or_update_messages_expansion_with_next_week_already_posted(
+        self, caplog, db_cleanup, mock_slack_bolt_async_app
+    ):
+        """
+        post_or_update_messages fails if it determines that a
+        weeks posts will require a new message(s), but the next week
+        has already had posts sent for it.
+        """
 
-    # Create a "channel" and a message
-    await database.add_channel(slack_id)
+        slack_id = "fake_slack_id"
 
-    # This message is for the next week
-    await database.create_message(
-        "2023-10-29 00:00:00+00:00",
-        "test",
-        "1698119853.135399",
-        slack_id,
-        1,
-    )
-    # Message for this week
-    await database.create_message(
-        "2023-10-22 00:00:00+00:00",
-        "test",
-        "1698119853.135399",
-        slack_id,
-        1,
-    )
+        # Create a "channel" and a message
+        await database.add_channel(slack_id)
 
-    # Try adding more message than what currently exists
-    await post_or_update_messages(
-        week, [{"text": "message 1", "blocks": []}, {"text": "message 2", "blocks": []}]
-    )
+        # This message is for the next week
+        await database.create_message(
+            "2023-10-29 00:00:00+00:00",
+            "test",
+            "1698119853.135399",
+            slack_id,
+            1,
+        )
+        # Message for this week
+        await database.create_message(
+            "2023-10-22 00:00:00+00:00",
+            "test",
+            "1698119853.135399",
+            slack_id,
+            1,
+        )
 
-    assert (
-        "Cannot update messages for 10/22/2023 for channel fake_slack_id. "
-        "New events have caused the number of messages needed to increase, "
-        "but the next week's post has already been sent. Cannot resize. "
-        "Existing message count: 1 --- New message count: 2." in caplog.text
-    )
+        # Try adding more message than what currently exists
+        await post_or_update_messages(
+            week,
+            [{"text": "message 1", "blocks": []}, {"text": "message 2", "blocks": []}],
+        )
 
+        assert (
+            "Cannot update messages for 10/22/2023 for channel fake_slack_id. "
+            "New events have caused the number of messages needed to increase, "
+            "but the next week's post has already been sent. Cannot resize. "
+            "Existing message count: 1 --- New message count: 2." in caplog.text
+        )
 
-@pytest.mark.asyncio
-async def test_post_or_update_messages_expansion_without_new_weeks_posts(
-    caplog, db_cleanup, mock_slack_bolt_async_app
-):
-    """
-    post_or_update_messages will allow for additional messages to be posted
-    as long as the next week hasn't had any posts sent for it yet.
-    """
+    @pytest.mark.asyncio
+    async def test_post_or_update_messages_expansion_without_new_weeks_posts(
+        self, caplog, db_cleanup, mock_slack_bolt_async_app
+    ):
+        """
+        post_or_update_messages will allow for additional messages to be posted
+        as long as the next week hasn't had any posts sent for it yet.
+        """
 
-    slack_id = "fake_slack_id_two"
+        slack_id = "fake_slack_id_two"
 
-    # Create a "channel" and a message
-    await database.add_channel(slack_id)
-    # Message for this week
-    await database.create_message(
-        "2023-10-22 00:00:00+00:00",
-        "test",
-        "1698119853.135399",
-        slack_id,
-        1,
-    )
+        # Create a "channel" and a message
+        await database.add_channel(slack_id)
+        # Message for this week
+        await database.create_message(
+            "2023-10-22 00:00:00+00:00",
+            "test",
+            "1698119853.135399",
+            slack_id,
+            1,
+        )
 
-    # Try adding more message than what currently exists
-    await post_or_update_messages(
-        week, [{"text": "message 1", "blocks": []}, {"text": "message 2", "blocks": []}]
-    )
+        # Try adding more message than what currently exists
+        await post_or_update_messages(
+            week,
+            [{"text": "message 1", "blocks": []}, {"text": "message 2", "blocks": []}],
+        )
 
-    assert (
-        "Cannot update messages for 10/22/2023 for channel fake_slack_id_two. "
-        "New events have caused the number of messages needed to increase, "
-        "but the next week's post has already been sent. Cannot resize. "
-        "Existing message count: 1 --- New message count: 2." not in caplog.text
-    )
+        assert (
+            "Cannot update messages for 10/22/2023 for channel fake_slack_id_two. "
+            "New events have caused the number of messages needed to increase, "
+            "but the next week's post has already been sent. Cannot resize. "
+            "Existing message count: 1 --- New message count: 2." not in caplog.text
+        )
 
-    messages = await database.get_messages(week)
+        messages = await database.get_messages(week)
 
-    # Make sure the second message was recorded as if it were posted
-    assert set(["message 1", "message 2"]) == {msg["message"] for msg in messages}
+        # Make sure the second message was recorded as if it were posted
+        assert set(["message 1", "message 2"]) == {msg["message"] for msg in messages}


### PR DESCRIPTION
Fixes #4 

# Summary
These changes make it so that only workspace admins are able to execute `/add_channel` and `/remove_channel` within their Slack workspace.

# Notes for Testing and Deploying
You will need to enable the [users:read](https://api.slack.com/scopes/users:read) Oauth scope within your app's settings.

![Screenshot_2023-11-19_20-03-12](https://github.com/hackgvl/slack-events-bot/assets/44626690/b7e13624-8d43-4fe3-bc5b-f44b9e75d095)


# Testing Plan
Unless you have two accounts that you can tinker with the recommended test plan involves manipulating the code slightly. :grimacing: 

1. Execute `/add_channel` in a workspace where you are an admin. Everything should operate as normal!
2. Hardcode `is_admin` in [src/auth.py](https://github.com/ThorntonMatthewD/slack-events-bot/blob/b1ce1f6fb1950e76e15b8121cb33301c837f4134/src/auth.py) to return `False` and reload your Slack bot.
```python
async def is_admin(user_id: str) -> bool:
    """
    Gets info for the Slack user executing the command and checks if
    they're a workspace admin.
    """
    return False
```
3. Reexecute the `/add_channel` command. This time you'll be greeted with this message:
![Screenshot_2023-11-19_19-54-51](https://github.com/hackgvl/slack-events-bot/assets/44626690/1e621a40-2918-41fd-ba4a-6f558af3cf08)
4. Feel free to repeat the same process for `/remove_channel`, and to also make sure that `/check_api` has remain untouched.
