### PR TITLE
Decrease `watchtower` Polling Interval and Add Orphaned Image Cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,5 +62,10 @@ services:
     container_name: watchtower
     profiles: ["autoupdating"]
     restart: always
+    environment:
+      # Poll for image updates every 15 minutes
+      - WATCHTOWER_POLL_INTERVAL=900
+      # Cleans up orphaned images upon pulling new ones
+      - WATCHTOWER_CLEANUP=true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
# Summary

Adds the following environmental variables to the [watchtower service](https://github.com/ThorntonMatthewD/slack-events-bot/blob/2fc79190e1fe8d8849c22a6f496f1029357a0c1a/docker-compose.yml#L60):

Env Var|Description|Value
---|---|---
[WATCHTOWER_POLL_INTERVAL](https://containrrr.dev/watchtower/arguments/#poll_interval)|The number of seconds between when watchtower will look for new images.|`900` (15 minutes)
[WATCHTOWER_CLEANUP](https://containrrr.dev/watchtower/arguments/#cleanup)|Determines whether or not old images should be removed after they have been updated.|`true`