### PR TITLE
Fix Coordinate Composition

### DIFF
--- a/src/event.py
+++ b/src/event.py
@@ -25,7 +25,10 @@ def parse_location(event_json):
             f"{event_json['venue']['state']} {event_json['venue']['zip']}"
         )
 
-    if event_json["venue"]["lat"] is not None and event_json["venue"]["lon"] is not None:
+    if (
+        event_json["venue"]["lat"] is not None
+        and event_json["venue"]["lon"] is not None
+    ):
         return f"lat/long: {event_json['venue']['lat']}, {event_json['venue']['lon']}"
 
     return f"{event_json['venue']['name']}"

--- a/src/event.py
+++ b/src/event.py
@@ -26,7 +26,7 @@ def parse_location(event_json):
         )
 
     if event_json["venue"]["lat"] is not None and event_json["venue"]["lat"]:
-        return f"lat/long: {event_json['venue']['lat']}, {event_json['venue']['lat']}"
+        return f"lat/long: {event_json['venue']['lat']}, {event_json['venue']['lon']}"
 
     return f"{event_json['venue']['name']}"
 

--- a/src/event.py
+++ b/src/event.py
@@ -25,7 +25,7 @@ def parse_location(event_json):
             f"{event_json['venue']['state']} {event_json['venue']['zip']}"
         )
 
-    if event_json["venue"]["lat"] is not None and event_json["venue"]["lat"]:
+    if event_json["venue"]["lat"] is not None and event_json["venue"]["lon"] is not None:
         return f"lat/long: {event_json['venue']['lat']}, {event_json['venue']['lon']}"
 
     return f"{event_json['venue']['name']}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,3 +101,36 @@ def mock_slack_bolt_async_app(request, monkeypatch):
     Monkeypatch slack_bolt.async_app's AsyncApp with our stub
     """
     monkeypatch.setattr(f"{request.param}.SLACK_APP", mocks.AsyncApp())
+
+
+@pytest.fixture
+def sample_event_date():
+    """Return fully-populated event dictionary"""
+    return {
+        "event_name": "Tankin' Around Greenville",
+        "group_name": "Greenville Tank Enthusiasts",
+        "group_url": "https://www.techafterfive.com/greenville/",
+        "venue": {
+            "name": "Gower Estates Park",
+            "address": "24 Evelyn Ave,",
+            "city": "Greenville",
+            "state": "SC",
+            "zip": "29607",
+            "country": "US",
+            "lat": "34.8300191",
+            "lon": "-82.3510954",
+        },
+        "url": "https://www.eventbrite.com/e/tanks-are-cool-123456789101",
+        "time": "2023-12-12T22:30:00Z",
+        "tags": "",
+        "rsvp_count": None,
+        "created_at": "2023-11-15T18:50:35Z",
+        "description": "Join us for a special event as we take a group trip to local parks to admire "
+        + "and appreciate the decommissioned military tanks that are on display.",
+        "uuid": "e70fb83b-df54-4333-9f02-1746ec1d62ee",
+        "nid": "1",
+        "data_as_of": "2023-12-07T16:40:14Z",
+        "status": "upcoming",
+        "service_id": "123456789101",
+        "service": "eventbrite",
+    }.copy()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def sample_event_date():
     return {
         "event_name": "Tankin' Around Greenville",
         "group_name": "Greenville Tank Enthusiasts",
-        "group_url": "https://www.techafterfive.com/greenville/",
+        "group_url": "https://www.tankinaroundgreenville.com",
         "venue": {
             "name": "Gower Estates Park",
             "address": "24 Evelyn Ave,",

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,43 @@
+"""
+Tests the parsing of events data
+"""
+
+import event
+
+
+def test_parsing_location_of_event_with_full_details(sample_event_date):
+    """Happy path scenario where all event fields are populated"""
+    result = event.parse_location(sample_event_date)
+
+    assert result == "Gower Estates Park at 24 Evelyn Ave, Greenville, SC 29607"
+
+
+def test_parsing_location_of_event_with_missing_venue(sample_event_date):
+    """Tests that the location is returned as None if a venue isn't provided"""
+    event_data_without_venue = sample_event_date
+    event_data_without_venue["venue"] = None
+
+    result = event.parse_location(event_data_without_venue)
+
+    assert result is None
+
+
+def test_parsing_location_of_event_missing_state(sample_event_date):
+    """Ensure coordinates are returned if the state is missing from venue info"""
+    event_data_without_state = sample_event_date
+    event_data_without_state["venue"]["state"] = None
+
+    result = event.parse_location(event_data_without_state)
+
+    assert result == "lat/long: 34.8300191, -82.3510954"
+
+
+def test_parsing_location_of_event_missing_state_and_latitude(sample_event_date):
+    """Ensure venue name is returned if state and latitude are missing from venue info"""
+    event_data_without_state_and_lat = sample_event_date
+    event_data_without_state_and_lat["venue"]["state"] = None
+    event_data_without_state_and_lat["venue"]["lat"] = None
+
+    result = event.parse_location(event_data_without_state_and_lat)
+
+    assert result == "Gower Estates Park"


### PR DESCRIPTION
# Summary
Fixes a bug where coordinates for events were being composed by using the latitude twice instead of latitude and then longitude.

|Before|After|
|---|---|
![Screenshot_2023-12-07_13-23-08](https://github.com/hackgvl/slack-events-bot/assets/44626690/0794f50c-93ea-42a9-a86a-d09b9067161a)|![Screenshot_2023-12-07_13-23-28](https://github.com/hackgvl/slack-events-bot/assets/44626690/040ba05c-d409-48d4-b6a8-a640acf71d36)
