### PR TITLE
Fix Total Message Count Calculation to Account for Headers

### DIFF
--- a/src/message_builder.py
+++ b/src/message_builder.py
@@ -13,7 +13,7 @@ from event import Event
 MAX_MESSAGE_CHARACTER_LENGTH = 3000
 # Approximate character length needed to accommodate post headers
 # ex: HackGreenville Events for the week of September 10 - 10 of 10
-HEADER_BUFFER_LENGTH = 66
+HEADER_BUFFER_LENGTH = 61
 
 
 async def build_header(week_start: datetime.datetime, index: int, total: int) -> dict:


### PR DESCRIPTION
Fixes #52

# Summary
Takes into account the headers added to each post (ex: "HackGreenville Events for the week of December 10 - 1 of 2") whenever calculating the total numbers of messages that will be needed in order to contain all of the events for a given week.

I chose 61 as the character count for the buffer to handle the longest header I'd anticipate seeing:
`HackGreenville Events for the week of September NN - YY of ZZ`

**Before/After For the Week of December 10th:**
|Post|Before|After|
|---|---|---|
|1|![Screenshot_2023-12-09_21-04-29](https://github.com/hackgvl/slack-events-bot/assets/44626690/0395295c-d7fa-41a9-97fb-b5f9a04e913a)|![Screenshot_2023-12-09_21-05-24](https://github.com/hackgvl/slack-events-bot/assets/44626690/9cbb958a-43e0-45d6-a74c-a49dba6de678)
|2|![Screenshot_2023-12-09_21-04-37](https://github.com/hackgvl/slack-events-bot/assets/44626690/dc08c7fe-f607-4701-a2d6-48ca6491c765)|![Screenshot_2023-12-09_21-05-32](https://github.com/hackgvl/slack-events-bot/assets/44626690/6c2eebc6-f7e8-4067-995b-bb56bc94572d)
