### PR TITLE
Add `users:read` Scope to app_manifest.yml

### DIFF
--- a/app_manifest.yml
+++ b/app_manifest.yml
@@ -33,6 +33,7 @@ oauth_config:
       - chat:write
       - chat:write.public
       - incoming-webhook
+      - users:read
 settings:
   org_deploy_enabled: false
   socket_mode_enabled: false


### PR DESCRIPTION
# Summary
The need for the [users:read](https://api.slack.com/scopes/users:read) scope was introduced as part of the command authorization work presented by #47. I forgot to add it to [app_manifest.yml](https://github.com/hackgvl/slack-events-bot/blob/6039e5fde8e16828fb1d8e48bfbf63fe6eb80b9e/app_manifest.yml#L30).