### PR TITLE
Verify Authenticity of Incoming Slack Requests

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -1,8 +1,15 @@
 """
 Logic for restricting the use of Slack commands to specific parties
+and validating incoming requests.
 """
-
+import hashlib
+import hmac
+import logging
+import os
+import time
 from functools import wraps
+
+from fastapi import HTTPException
 
 from config import SLACK_APP
 
@@ -42,3 +49,68 @@ def admin_required(command):
         )
 
     return auth_wrapper
+
+
+async def generate_expected_hash(req_timestamp: str, req_body: bytes) -> hmac.HMAC:
+    """
+    Creates an HMAC object by piecing together our signing secret and
+    the following information provided by the request to our endpoint:
+       - The X-Slack-Request-Timestamp header
+       - The request's body
+
+    The hex digest will be hashed using the SHA256 algo.
+
+    This hash can be used to compare with the X-Slack-Signature of the request
+    to determine if the request originated from Slack.
+    """
+    singing_secret_as_byte_key = os.getenv("SIGNING_SECRET", "").encode("UTF-8")
+
+    return hmac.new(
+        singing_secret_as_byte_key,
+        f"v0:{req_timestamp}:".encode() + req_body,
+        hashlib.sha256,
+    )
+
+
+def validate_slack_command_source(request_invocation):
+    """
+    Validates that incoming requests to execute Slack commands have
+    indeed originated from Slack and not elsewhere.
+
+    Raises a generic server error if anything seems out of order.
+    """
+
+    @wraps(request_invocation)
+    async def slack_validation_wrapper(*args, **kwargs):
+        request = kwargs["req"]
+
+        # Check for possible replay attacks
+        if (
+            abs(time.time() - int(request.headers["X-Slack-Request-Timestamp"]))
+            > 60 * 5
+        ):
+            logging.warning("Possible replay attack has been logged.")
+            raise HTTPException(
+                status_code=400, detail="There was an issue with your request."
+            )
+
+        expected_hash = await generate_expected_hash(
+            request.headers["X-Slack-Request-Timestamp"], await request.body()
+        )
+        expected_signature = f"v0={expected_hash.hexdigest()}"
+
+        # If signatures do not match then either there's a software bug or
+        # the request wasn't signed by Slack.
+        if not hmac.compare_digest(
+            expected_signature, request.headers["X-Slack-Signature"]
+        ):
+            logging.warning(
+                "A request to invoke a Slack command failed the signature check."
+            )
+            raise HTTPException(
+                status_code=400, detail="There was an issue with your request."
+            )
+
+        return await request_invocation(*args, **kwargs)
+
+    return slack_validation_wrapper

--- a/src/server.py
+++ b/src/server.py
@@ -19,6 +19,7 @@ from fastapi.responses import PlainTextResponse
 from starlette.types import Message
 
 import database
+from auth import validate_slack_command_source
 from bot import periodically_check_api, periodically_delete_old_messages
 from config import API, SLACK_APP_HANDLER
 
@@ -133,8 +134,10 @@ async def rate_limit_check_api(
 
 
 @API.post("/slack/events")
+@validate_slack_command_source
 async def slack_endpoint(req: Request):
     """The front door for all Slack requests"""
+
     return await SLACK_APP_HANDLER.handle(req)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,8 @@ from fastapi.testclient import TestClient
 
 import bot
 import config
-import server
 import database
+import server
 
 
 @pytest.fixture

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,7 @@
 """
 Tests functions contained in src/auth.py
 """
+import os
 
 import pytest
 
@@ -24,3 +25,14 @@ class TestAuth:
         result = await auth.is_admin("admin_user")
 
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_generation_of_expected_hash(self, mock_slack_bolt_async_app):
+        os.environ["SIGNING_SECRET"] = "super_secret"
+
+        result = await auth.generate_expected_hash("946702800", b"I am a test body")
+
+        assert (
+            result.hexdigest()
+            == "a02c228c8010f0725da1a2a2524fb0f1dced42c5d56ed1ea11cdb603cf72a434"
+        )


### PR DESCRIPTION
Fixes #33

# Summary
Prior to entertaining a request send to `/slack/events` and initiating a command a check is made using the following information to determine if the `X-Slack-Signature` header is what we would expect given that Slack is (hopefully) the only party to know the application's signing secret:
- The [`SIGNING_SECRET`](https://github.com/ThorntonMatthewD/slack-events-bot/blob/e1803bfcd05348b03c2f3b6c47a86b454099b34a/.envrc.example#L4)
- The `X-Slack-Request-Timestamp` header of the request
- The request's body

If the value contined in the `X-Slack-Signature` header doesn't match what we come up with using those same pieces of information, then the request will be considered fradulent. A warning will be logged and the client will receive a generic [HTTP 400 error](https://http.cat/400).

There is also a simple check for possible [replay attacks](https://csrc.nist.gov/glossary/term/replay_attack) where any requests with `X-Slack-Request-Timestamp` values more than 5 minutes off from the current time are also treated as being fradulent. This was taken from step 2 of [this documentation page's "Validating a request" section](https://api.slack.com/authentication/verifying-requests-from-slack#making__validating-a-request) on Slack's site.